### PR TITLE
Jupyter: Open VS Code in a new window

### DIFF
--- a/jupyter/code
+++ b/jupyter/code
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-NODE_TLS_REJECT_UNAUTHORIZED=0 code .
+NODE_TLS_REJECT_UNAUTHORIZED=0 code -n .


### PR DESCRIPTION
## Summary
- Add `-n` flag to the `code` command in `jupyter/code` so VS Code opens in a new window instead of reusing an existing one.

## Test plan
- [ ] Open Jupyter environment and run the `code` command
- [ ] Verify VS Code opens in a new window